### PR TITLE
fix: don't set agentConversationContextId

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
     </script>
 
     <script language="javascript">
-  window.$_TYagent_ = {mode: 'embedded', startMode: 'minimized', rootElementId: 'ty__agent', agentConversationContextId: '${request.path_params.agent_context_id}'};
+  window.$_TYagent_ = {mode: 'embedded', startMode: 'minimized', rootElementId: 'ty__agent'};
     </script>
     
     


### PR DESCRIPTION
agentConversationContextId cannot be derived from path parameters and therefore will be set to a failure value. Simply not setting it will start a chat without conversation context ªguest context e.G.)